### PR TITLE
Add DeepSeek API example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,21 @@
-# ds
+# DeepSeek API Example
+
+This repository contains a simple Python example showing how you might call the DeepSeek API using HTTP requests.
+
+The example code is located in `deepseek_api_example.py`. It demonstrates how to send a POST request to a hypothetical DeepSeek endpoint using the `requests` library. You will need to replace the placeholder URL and provide your own API key and parameters according to the official DeepSeek API documentation.
+
+## Running the Example
+
+1. Install the dependencies:
+   ```bash
+   pip install requests
+   ```
+
+2. Set your DeepSeek API key as an environment variable named `DEEPSEEK_API_KEY`.
+
+3. Run the script:
+   ```bash
+   python deepseek_api_example.py
+   ```
+
+The script will print the JSON response from the API.

--- a/deepseek_api_example.py
+++ b/deepseek_api_example.py
@@ -1,0 +1,23 @@
+import os
+import requests
+
+API_URL = "https://api.deepseek.com/v1/example"  # Replace with the actual endpoint
+API_KEY = os.getenv("DEEPSEEK_API_KEY")
+
+if not API_KEY:
+    raise RuntimeError("Set the DEEPSEEK_API_KEY environment variable.")
+
+headers = {
+    "Authorization": f"Bearer {API_KEY}",
+    "Content-Type": "application/json",
+}
+
+payload = {
+    "prompt": "Hello from DeepSeek!",
+    # Add additional parameters required by the DeepSeek API here
+}
+
+response = requests.post(API_URL, headers=headers, json=payload, timeout=30)
+response.raise_for_status()
+
+print(response.json())


### PR DESCRIPTION
## Summary
- rewrite README with instructions
- add `deepseek_api_example.py` sample using `requests`

## Testing
- `python -m py_compile deepseek_api_example.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6843b3d206e88320a8581d70304b0f44